### PR TITLE
fix: proper error if `--config` is not given and config file does not…

### DIFF
--- a/bazel-cc-sysroot-generator
+++ b/bazel-cc-sysroot-generator
@@ -342,7 +342,7 @@ if __name__ == "__main__":
         elif os.path.exists("sysroot-config.toml"):
             config_file = "sysroot-config.toml"
 
-    if not os.path.exists(config_file):
+    if config_file is None or not os.path.exists(config_file):
         raise SystemExit(
             f"{config_file}: error: file does not exist, use --config to pass another path"
         )


### PR DESCRIPTION
… exist