### PR TITLE
Improve macOS example

### DIFF
--- a/examples/macos-config.toml
+++ b/examples/macos-config.toml
@@ -1,12 +1,14 @@
 [[platforms]]
 os = "macos"
 deleted_patterns = [
-  "*Swift*",
-  "*swift*",
+  "*.swift*",
   "*iOSSupport*",
   "*Ruby.framework*",
+  "*Swift*.framework",
+  "*SwiftUI*",
   "System/Cryptexes",
   "System/Library/Perl",
-  "usr/share",
+  "usr/lib/swift",
   "usr/libexec",
+  "usr/share",
 ]


### PR DESCRIPTION
The previous patterns deleted some header files that had Swift in the
name and are also required for C* compiles
