### PR TITLE
Ignore sanitizer default ignore lists in include rule

### DIFF
--- a/reduce-llvm-toolchain
+++ b/reduce-llvm-toolchain
@@ -111,7 +111,10 @@ filegroup(
 
 filegroup(
     name = "include",
-    srcs = glob(["lib/clang/*/include/**"]),
+    srcs = glob([
+        "lib/clang/*/include/**",
+        "lib/clang/*/share/**/*.txt",  # sanitizer default ignore lists
+    ]),
 )
 
 filegroup(


### PR DESCRIPTION
By default compiles look up asan_ignorelist.txt and friends from the
share directory. It's a bit weird that these are part of something
called include but should be fine for now. Maybe we should rename later.
